### PR TITLE
Add ClockWise full-stack skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# ClockWise
+
+ClockWise is a simple time and attendance tracker with a React frontend and
+Node.js/Express backend powered by MongoDB. It can be run locally using Docker
+compose.
+
+## Requirements
+- Docker and Docker Compose
+
+## Running locally
+
+```bash
+docker-compose up --build
+```
+
+The frontend will be available on `http://localhost:3000`, the backend API on
+`http://localhost:5000`, and MongoDB on `mongodb://localhost:27017`.
+
+## Project Structure
+```
+frontend/   # React + Tailwind application
+backend/    # Express API and Slack integration
+k8s/        # Kubernetes deployment manifests (placeholders)
+```

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+MONGO_URI=mongodb://mongo:27017/clockwisedb
+JWT_SECRET=your_jwt_secret
+SLACK_WEBHOOK=

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --production --silent && npm cache clean --force
+COPY . .
+EXPOSE 5000
+CMD ["npm","start"]

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,116 @@
+import express from 'express';
+import mongoose from 'mongoose';
+import cors from 'cors';
+import dotenv from 'dotenv';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import axios from 'axios';
+
+dotenv.config();
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const PORT = process.env.PORT || 5000;
+const JWT_SECRET = process.env.JWT_SECRET || 'secret';
+const SLACK_WEBHOOK = process.env.SLACK_WEBHOOK || '';
+
+mongoose.connect(process.env.MONGO_URI, {
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
+}).then(() => console.log('Mongo connected')).catch(err => console.error(err));
+
+// Models
+const userSchema = new mongoose.Schema({
+  name: String,
+  email: String,
+  password: String,
+});
+
+const attendanceSchema = new mongoose.Schema({
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  date: String,
+  punchIn: Date,
+  punchOut: Date,
+});
+
+const User = mongoose.model('User', userSchema);
+const AttendanceRecord = mongoose.model('AttendanceRecord', attendanceSchema);
+
+// Helpers
+function authMiddleware(req, res, next) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader) return res.status(401).json({ error: 'No token' });
+  const token = authHeader.split(' ')[1];
+  try {
+    const decoded = jwt.verify(token, JWT_SECRET);
+    req.user = decoded;
+    next();
+  } catch (err) {
+    res.status(401).json({ error: 'Invalid token' });
+  }
+}
+
+// Routes
+app.post('/login', async (req, res) => {
+  const { email, password } = req.body;
+  const user = await User.findOne({ email });
+  if (!user) return res.status(401).json({ error: 'User not found' });
+  const match = await bcrypt.compare(password, user.password);
+  if (!match) return res.status(401).json({ error: 'Invalid password' });
+  const token = jwt.sign({ id: user._id, name: user.name, email: user.email }, JWT_SECRET);
+  res.json({ token });
+});
+
+app.post('/punchin', authMiddleware, async (req, res) => {
+  const today = new Date().toISOString().slice(0, 10);
+  let record = await AttendanceRecord.findOne({ userId: req.user.id, date: today });
+  if (!record) {
+    record = new AttendanceRecord({ userId: req.user.id, date: today });
+  }
+  record.punchIn = new Date();
+  await record.save();
+  res.json(record);
+});
+
+app.post('/punchout', authMiddleware, async (req, res) => {
+  const today = new Date().toISOString().slice(0, 10);
+  let record = await AttendanceRecord.findOne({ userId: req.user.id, date: today });
+  if (!record) return res.status(400).json({ error: 'No punch in found' });
+  record.punchOut = new Date();
+  await record.save();
+
+  // Alert if more than 12h
+  const diff = (record.punchOut - record.punchIn) / 3600000;
+  if (diff > 12 && SLACK_WEBHOOK) {
+    await axios.post(SLACK_WEBHOOK, { text: `User ${req.user.email} logged ${diff.toFixed(2)} hours today` });
+  }
+
+  res.json(record);
+});
+
+app.get('/summary', authMiddleware, async (req, res) => {
+  const today = new Date();
+  const startOfWeek = new Date(today);
+  startOfWeek.setDate(today.getDate() - today.getDay());
+
+  const records = await AttendanceRecord.find({
+    userId: req.user.id,
+    date: { $gte: startOfWeek.toISOString().slice(0, 10) },
+  });
+
+  let todayHours = 0;
+  let weekHours = 0;
+  records.forEach(r => {
+    if (r.punchIn && r.punchOut) {
+      const hours = (r.punchOut - r.punchIn) / 3600000;
+      weekHours += hours;
+      if (r.date === today.toISOString().slice(0, 10)) todayHours = hours;
+    }
+  });
+
+  res.json({ todayHours, weekHours });
+});
+
+app.listen(PORT, () => console.log(`Backend running on port ${PORT}`));

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "clockwise-backend",
+  "version": "1.0.0",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "axios": "^1.6.7",
+    "bcryptjs": "^2.4.3",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.1",
+    "mongoose": "^7.3.1"
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.8'
+services:
+  mongo:
+    image: mongo:5
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo-data:/data/db
+  backend:
+    build: ./backend
+    ports:
+      - "5000:5000"
+    environment:
+      - MONGO_URI=mongodb://mongo:27017/clockwisedb
+      - SLACK_WEBHOOK=
+    depends_on:
+      - mongo
+  frontend:
+    build: ./frontend
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend
+volumes:
+  mongo-data:

--- a/frontend/.babelrc
+++ b/frontend/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
+}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:18-alpine as build
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --silent && npm cache clean --force
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/public /usr/share/nginx/html
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 3000
+CMD ["nginx","-g","daemon off;"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "clockwise-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "webpack serve --mode development --open --hot",
+    "build": "webpack --mode production"
+  },
+  "dependencies": {
+    "axios": "^1.6.7",
+    "chart.js": "^4.4.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.14.1"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.23.7",
+    "@babel/preset-env": "^7.23.7",
+    "@babel/preset-react": "^7.22.15",
+    "babel-loader": "^9.1.3",
+    "css-loader": "^6.8.1",
+    "postcss": "^8.4.31",
+    "postcss-loader": "^7.3.3",
+    "tailwindcss": "^3.3.5",
+    "webpack": "^5.88.1",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1",
+    "style-loader": "^3.3.3"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ClockWise</title>
+</head>
+<body class="bg-gray-100">
+  <div id="root"></div>
+  <script src="/bundle.js"></script>
+</body>
+</html>

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { Chart } from 'chart.js/auto';
+
+export default function Dashboard() {
+  const [summary, setSummary] = useState({ todayHours: 0, weekHours: 0 });
+  const [chart, setChart] = useState(null);
+
+  const token = localStorage.getItem('token');
+  const api = axios.create({
+    baseURL: '/api',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  const punchIn = () => api.post('/punchin').then(fetchSummary);
+  const punchOut = () => api.post('/punchout').then(fetchSummary);
+
+  function fetchSummary() {
+    api.get('/summary').then(res => setSummary(res.data));
+  }
+
+  useEffect(() => {
+    fetchSummary();
+  }, []);
+
+  useEffect(() => {
+    if (!chart) {
+      const ctx = document.getElementById('hoursChart').getContext('2d');
+      setChart(new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels: ['Today', 'This Week'],
+          datasets: [{
+            label: 'Hours Worked',
+            data: [summary.todayHours, summary.weekHours],
+            backgroundColor: ['#60a5fa', '#3b82f6'],
+          }],
+        },
+        options: {
+          responsive: true,
+        },
+      }));
+    } else {
+      chart.data.datasets[0].data = [summary.todayHours, summary.weekHours];
+      chart.update();
+    }
+  }, [summary]);
+
+  return (
+    <div className="p-4 max-w-xl mx-auto">
+      <h1 className="text-2xl mb-4">Dashboard</h1>
+      <div className="mb-4">
+        <button className="bg-green-500 text-white px-4 py-2 mr-2" onClick={punchIn}>Punch In</button>
+        <button className="bg-red-500 text-white px-4 py-2" onClick={punchOut}>Punch Out</button>
+      </div>
+      <div className="mb-2">Today: {summary.todayHours.toFixed(2)} hours</div>
+      <div className="mb-4">This Week: {summary.weekHours.toFixed(2)} hours</div>
+      <canvas id="hoursChart" height="200"></canvas>
+    </div>
+  );
+}

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
+
+export default function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const navigate = useNavigate();
+
+  const submit = async e => {
+    e.preventDefault();
+    try {
+      const res = await axios.post('/api/login', { email, password });
+      localStorage.setItem('token', res.data.token);
+      navigate('/');
+    } catch (err) {
+      setError('Invalid credentials');
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center h-screen bg-gray-100">
+      <form onSubmit={submit} className="bg-white p-8 rounded shadow w-80">
+        <h1 className="text-2xl mb-4 text-center">ClockWise Login</h1>
+        {error && <div className="text-red-500 mb-2">{error}</div>}
+        <input
+          className="w-full mb-2 p-2 border"
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+        />
+        <input
+          className="w-full mb-4 p-2 border"
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+        <button className="w-full bg-blue-500 text-white p-2" type="submit">
+          Login
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import Login from './components/Login';
+import Dashboard from './components/Dashboard';
+import './index.css';
+
+function App() {
+  const token = localStorage.getItem('token');
+  return (
+    <Router>
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route path="/" element={token ? <Dashboard /> : <Navigate to="/login" />} />
+      </Routes>
+    </Router>
+  );
+}
+
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./src/**/*.{js,jsx,ts,tsx,html}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,0 +1,41 @@
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.jsx',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js',
+    publicPath: '/',
+  },
+  resolve: {
+    extensions: ['.js', '.jsx'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-env', '@babel/preset-react'],
+          },
+        },
+      },
+      {
+        test: /\.css$/i,
+        use: ['style-loader', 'css-loader', 'postcss-loader'],
+      },
+    ],
+  },
+  devServer: {
+    historyApiFallback: true,
+    static: {
+      directory: path.join(__dirname, 'public'),
+    },
+    port: 3000,
+    proxy: {
+      '/api': 'http://localhost:5000',
+    },
+  },
+};

--- a/k8s/backend-deployment.yaml
+++ b/k8s/backend-deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clockwise-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: clockwise-backend
+  template:
+    metadata:
+      labels:
+        app: clockwise-backend
+    spec:
+      containers:
+        - name: backend
+          image: your-backend-image
+          env:
+            - name: MONGO_URI
+              value: mongodb://clockwise-mongo:27017/clockwisedb
+          ports:
+            - containerPort: 5000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clockwise-backend
+spec:
+  selector:
+    app: clockwise-backend
+  ports:
+    - port: 5000
+      targetPort: 5000
+  type: ClusterIP

--- a/k8s/frontend-deployment.yaml
+++ b/k8s/frontend-deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clockwise-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: clockwise-frontend
+  template:
+    metadata:
+      labels:
+        app: clockwise-frontend
+    spec:
+      containers:
+        - name: frontend
+          image: your-frontend-image
+          ports:
+            - containerPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clockwise-frontend
+spec:
+  selector:
+    app: clockwise-frontend
+  ports:
+    - port: 80
+      targetPort: 3000
+  type: ClusterIP

--- a/k8s/mongo-deployment.yaml
+++ b/k8s/mongo-deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clockwise-mongo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: clockwise-mongo
+  template:
+    metadata:
+      labels:
+        app: clockwise-mongo
+    spec:
+      containers:
+        - name: mongo
+          image: mongo:5
+          ports:
+            - containerPort: 27017
+          volumeMounts:
+            - name: mongo-data
+              mountPath: /data/db
+      volumes:
+        - name: mongo-data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clockwise-mongo
+spec:
+  selector:
+    app: clockwise-mongo
+  ports:
+    - port: 27017
+      targetPort: 27017
+  type: ClusterIP


### PR DESCRIPTION
## Summary
- implement README with project overview
- add docker-compose for frontend, backend, and MongoDB
- implement backend Express app with Mongoose and Slack alert
- implement minimal React frontend with Tailwind UI
- provide Dockerfiles and placeholder Kubernetes manifests

## Testing
- `node -v`
- `npm -v`


------
https://chatgpt.com/codex/tasks/task_e_688136602080833091d383e559e89610